### PR TITLE
InputStream read chunks EOF fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.3.61</kotlin.version>
+        <kotlin.version>1.4.10</kotlin.version>
         <kotlin-logging.version>1.5.3</kotlin-logging.version>
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>

--- a/src/main/kotlin/xyz/capybara/clamav/ClamavClient.kt
+++ b/src/main/kotlin/xyz/capybara/clamav/ClamavClient.kt
@@ -10,6 +10,7 @@ import java.io.File
 import java.io.InputStream
 import java.net.InetSocketAddress
 import java.nio.file.Path
+import kotlin.jvm.Throws
 
 /**
  * Kotlin ClamAV client

--- a/src/main/kotlin/xyz/capybara/clamav/commands/Command.kt
+++ b/src/main/kotlin/xyz/capybara/clamav/commands/Command.kt
@@ -9,6 +9,7 @@ import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.SocketChannel
 import java.nio.charset.StandardCharsets
+import kotlin.jvm.Throws
 
 internal abstract class Command<out T> {
     abstract val commandString: String

--- a/src/main/kotlin/xyz/capybara/clamav/commands/scan/InStream.kt
+++ b/src/main/kotlin/xyz/capybara/clamav/commands/scan/InStream.kt
@@ -29,7 +29,7 @@ internal class InStream(private val inputStream: InputStream) : ScanCommand() {
                 val length = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN)
                 val data = ByteArray(CHUNK_SIZE)
                 var chunkSize = CHUNK_SIZE
-                while (chunkSize == CHUNK_SIZE) {
+                while (chunkSize != -1) {
                     chunkSize = inputStream.read(data)
                     if (chunkSize > 0) {
                         length.clear()


### PR DESCRIPTION
- inputStream read ends when it reaches to the end of the file (EOF), (not when the received chunks size is zero) (fixes #7) 
- update kotlin version to the latest (fixes #10)